### PR TITLE
Fix: Wait for errors module before init (fixes #5)

### DIFF
--- a/lib/ConfigModule.js
+++ b/lib/ConfigModule.js
@@ -28,6 +28,9 @@ class ConfigModule extends AbstractModule {
     this.publicAttributes = []
 
     try {
+      // need to wait for errors to ensure correct logging
+      await this.app.waitForModule('errors')
+
       await this.storeUserSettings()
       await this.storeEnvSettings()
       await this.storeSchemaSettings()


### PR DESCRIPTION
Fixes #5

[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

### Fix
* Fixes display of config errors thrown prior to errors module initialisation


