### PR TITLE
Update: Format config defaults with indentation (fixes #34)

### DIFF
--- a/docs/plugins/configuration.js
+++ b/docs/plugins/configuration.js
@@ -69,6 +69,6 @@ export default class Configuration {
    * Returns a string formatted nicely for markdown
    */
   defaultToMd (config) {
-    return JSON.stringify(config.default)
+    return JSON.stringify(config.default, null, 2)?.replaceAll('\n', '\n    ')
   }
 }


### PR DESCRIPTION
Fixes #34

### Update
* Modified `defaultToMd` method in the Configuration plugin to pretty-print JSON with indentation (2 spaces) for improved readability in documentation output
* Added `replaceAll` to handle newline indentation for multi-line JSON values

### Testing
1. Generate documentation and verify config default values are now formatted with proper indentation
2. Confirm multi-line JSON values display correctly with maintained indentation