### PR TITLE
Fix: Use const for immutable variable (fixes #37)

### DIFF
--- a/docs/plugins/configuration.js
+++ b/docs/plugins/configuration.js
@@ -69,7 +69,7 @@ export default class Configuration {
    * Returns a string formatted nicely for markdown
    */
   defaultToMd (config) {
-    let s = JSON.stringify(config.default, null, 2)
+    const s = JSON.stringify(config.default, null, 2)
     return s?.length < 75 ? s : s?.replaceAll('\n', '\n    ')
   }
 }


### PR DESCRIPTION
Fixes #37

### Fix
* Change `let` to `const` for the immutable variable `s` in the `defaultToMd` method, since the value is never reassigned