### PR TITLE
Fix: Update manual sections (fixes #39)

### DIFF
--- a/adapt-authoring.json
+++ b/adapt-authoring.json
@@ -5,8 +5,7 @@
     "manualPlugins": ["docs/plugins/configuration.js"],
     "manualPages": {
       "configuration.md": "reference",
-      "configure-environment.md": "getting-started",
-      "defining-config.md": "basics"
+      "configure-environment.md": "getting-started"
     }
   }
 }


### PR DESCRIPTION
https://github.com/adapt-security/adapt-authoring-config/issues/39

### Fix
* Removed unused manual page entry for defining-config.md from the manualPages configuration