### PR TITLE
Update: Remove unnecessary await from synchronous schema calls

### DIFF
--- a/lib/ConfigModule.js
+++ b/lib/ConfigModule.js
@@ -158,7 +158,7 @@ class ConfigModule extends AbstractModule {
     const schemaPath = path.resolve(pkg.rootDir, 'conf/config.schema.json')
     let schema
     try {
-      schema = await (await jsonschema.createSchema(schemaPath)).build()
+      schema = jsonschema.createSchema(schemaPath).build()
     } catch (e) {
       return
     }

--- a/lib/ConfigModule.js
+++ b/lib/ConfigModule.js
@@ -128,21 +128,21 @@ class ConfigModule extends AbstractModule {
       return a.name.localeCompare(b.name)
     })
     const coreDep = deps.find(d => isCore(d))
-    if (coreDep) await this.processModuleSchema(coreDep, jsonschema)
+    if (coreDep) this.processModuleSchema(coreDep, jsonschema)
 
-    const promises = deps.filter(d => !isCore(d)).map(d => this.processModuleSchema(d, jsonschema))
-    let hasErrored = false;
-
-    (await Promise.allSettled(promises)).forEach(r => {
-      if (r.status === 'rejected') {
+    let hasErrored = false
+    for (const d of deps.filter(d => !isCore(d))) {
+      try {
+        this.processModuleSchema(d, jsonschema)
+      } catch (e) {
         hasErrored = true
-        if (r.reason?.data?.errors) {
-          console.log(`${r.reason.modName}: ${r.reason.data.errors}`)
+        if (e?.data?.errors) {
+          console.log(`${e.modName}: ${e.data.errors}`)
         } else {
-          console.log(r.reason)
+          console.log(e)
         }
       }
-    })
+    }
     if (hasErrored) throw new Error()
   }
 
@@ -150,9 +150,8 @@ class ConfigModule extends AbstractModule {
    * Processes and validates a single module config schema (checks the user config specifies any required fields, and that they are the expected type)
    * @param {Object} pkg Package.json data
    * @param {JsonSchemaModule} jsonschema Module instance for validation
-   * @return {Promise}
    */
-  async processModuleSchema (pkg, jsonschema) {
+  processModuleSchema (pkg, jsonschema) {
     if (!pkg.name || !pkg.rootDir) return
 
     const schemaPath = path.resolve(pkg.rootDir, 'conf/config.schema.json')
@@ -168,7 +167,7 @@ class ConfigModule extends AbstractModule {
       return { ...m, [k]: this.get(`${pkg.name}.${k}`) }
     }, {})
     try {
-      data = await schema.validate(data)
+      data = schema.validate(data)
     } catch (e) {
       e.modName = pkg.name
       throw e


### PR DESCRIPTION
### Fixes adapt-security/adapt-authoring-jsonschema#58

### Update
* Remove double `await` from `createSchema().build()` in `processModuleSchema` — both calls are now synchronous after adapt-schemas v3.0.0

### Testing
1. Run `npm run dev` and verify module config schemas load without errors
2. Run `npm test`