### PR TITLE
Update: Replace jsonschema module dep with adapt-schemas

### DIFF
--- a/lib/ConfigModule.js
+++ b/lib/ConfigModule.js
@@ -1,5 +1,6 @@
 /* eslint no-console: 0 */
 import { AbstractModule } from 'adapt-authoring-core'
+import { Schemas } from 'adapt-schemas'
 import chalk from 'chalk'
 import { envVarToConfigKey } from './utils.js'
 import fs from 'fs/promises'
@@ -119,7 +120,8 @@ class ConfigModule extends AbstractModule {
    * @return {Promise}
    */
   async storeSchemaSettings () {
-    const jsonschema = await this.app.waitForModule('jsonschema')
+    const schemas = new Schemas()
+
     const isCore = d => d.name === this.app.name
     const deps = Object.values(this.app.dependencies).sort((a, b) => {
       // put core first as other modules may use its config values
@@ -128,12 +130,12 @@ class ConfigModule extends AbstractModule {
       return a.name.localeCompare(b.name)
     })
     const coreDep = deps.find(d => isCore(d))
-    if (coreDep) this.processModuleSchema(coreDep, jsonschema)
+    if (coreDep) this.processModuleSchema(coreDep, schemas)
 
     let hasErrored = false
     for (const d of deps.filter(d => !isCore(d))) {
       try {
-        this.processModuleSchema(d, jsonschema)
+        this.processModuleSchema(d, schemas)
       } catch (e) {
         hasErrored = true
         if (e?.data?.errors) {
@@ -149,15 +151,15 @@ class ConfigModule extends AbstractModule {
   /**
    * Processes and validates a single module config schema (checks the user config specifies any required fields, and that they are the expected type)
    * @param {Object} pkg Package.json data
-   * @param {JsonSchemaModule} jsonschema Module instance for validation
+   * @param {Schemas} schemas Schemas library instance for validation
    */
-  processModuleSchema (pkg, jsonschema) {
+  processModuleSchema (pkg, schemas) {
     if (!pkg.name || !pkg.rootDir) return
 
     const schemaPath = path.resolve(pkg.rootDir, 'conf/config.schema.json')
     let schema
     try {
-      schema = jsonschema.createSchema(schemaPath).build()
+      schema = schemas.createSchema(schemaPath).build()
     } catch (e) {
       return
     }

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "repository": "github:adapt-security/adapt-authoring-config",
   "dependencies": {
     "adapt-authoring-core": "^2.0.0",
+    "adapt-schemas": "^3.1.0",
     "chalk": "^5.3.0",
     "glob": "^13.0.0"
   },
   "peerDependencies": {
     "adapt-authoring-auth": "^2.0.0",
     "adapt-authoring-errors": "^1.1.2",
-    "adapt-authoring-jsonschema": "^1.2.0",
     "adapt-authoring-server": "^2.0.0"
   },
   "devDependencies": {

--- a/tests/configModule.spec.js
+++ b/tests/configModule.spec.js
@@ -19,8 +19,7 @@ describe('ConfigModule', () => {
         const mocks = {
           errors: { LOAD_ERROR: new Error('load') },
           auth: { unsecureRoute: () => {} },
-          server: { api: { createChildRouter: () => noopRouter } },
-          jsonschema: { createSchema: async () => ({ build: async () => ({}) }) }
+          server: { api: { createChildRouter: () => noopRouter } }
         }
         const results = names.map(n => mocks[n] || {})
         return results.length === 1 ? results[0] : results


### PR DESCRIPTION
### Fixes #65

### Update
- Replaced `adapt-authoring-jsonschema` peer dependency with direct `adapt-schemas` dependency
- `storeSchemaSettings` now creates a local `Schemas` instance instead of waiting for the jsonschema module
- Removed `waitForModule('jsonschema')` call, simplifying boot order and eliminating potential circular dependency
- Updated test mocks to remove jsonschema mock

### Testing
- All 20 existing tests pass
- Standard.js linting passes